### PR TITLE
fix: move optional httpx import to safe location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ number as needed.
 
 ### Fixed
 
-- move optional import into safe location
+- move optional `httpx` import into safe location
 
 ## [0.1.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ number as needed.
 
 ## [Unreleased]
 
+## [0.1.2]
+
+### Fixed
+
+- move optional import into safe location
+
 ## [0.1.1]
 
 ### Fixed
@@ -35,5 +41,6 @@ number as needed.
 - Nothing.
 
 [Unreleased]: <https://github.com/stactools-packages/glad-global-forest-change/tree/main/>
+[0.1.2]: <https://github.com/stactools-packages/glad-global-forest-change/releases/tag/0.1.2>
 [0.1.1]: <https://github.com/stactools-packages/glad-global-forest-change/releases/tag/0.1.1>
 [0.1.0]: <https://github.com/stactools-packages/glad-global-forest-change/releases/tag/0.1.0>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "stactools-glad-global-forest-change"
-version = "0.1.1"
+version = "0.1.2"
 description = "stactools package for the GLAD Global Forest Change dataset"
 readme = "README.md"
 authors = [{ name = "Henry Rodman", email = "henry@developmentseed.org" }]

--- a/src/stactools/glad_global_forest_change/cogs.py
+++ b/src/stactools/glad_global_forest_change/cogs.py
@@ -10,7 +10,6 @@ from datetime import timedelta
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-import httpx
 import rasterio
 from rasterio.io import MemoryFile
 
@@ -29,6 +28,8 @@ def to_url(s: str) -> str:
 
 def get_file_list(assets: Tuple[str, ...]) -> List[str]:
     """Get the list of raw files for a set of assets"""
+    import httpx
+
     file_list: List[str] = []
     for asset in assets:
         if asset not in ASSETS:

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 
 [[package]]
@@ -2553,7 +2554,7 @@ wheels = [
 
 [[package]]
 name = "stactools-glad-global-forest-change"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "parse" },
@@ -2604,6 +2605,7 @@ requires-dist = [
     { name = "stactools", specifier = ">=0.5.0" },
     { name = "tqdm", marker = "extra == 'cogs'", specifier = ">=4.67.1" },
 ]
+provides-extras = ["cogs"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
to use this tool with `uvx` we need to be more careful about optional dependencies.